### PR TITLE
pnpm -> npm workaround

### DIFF
--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,7 +3,7 @@
 interface Env {
 	TOKEN_CACHE: KVNamespace;
 	NODE_VERSION: "22";
-	NPM_CONFIG_USER_AGENT: "pnpm/9.x.x";
+	NPM_CONFIG_USER_AGENT: "npm/10.x.x";
 	PETFINDER_API_CLIENT_ID: string;
 	PETFINDER_API_SECRET: string;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,7 +15,7 @@ kv_namespaces = [
 
 [env.production.vars]
 NODE_VERSION = "22"
-NPM_CONFIG_USER_AGENT = "pnpm/9.x.x"
+NPM_CONFIG_USER_AGENT = "npm/10.x.x"
 
 [env.preview]
 name = "scsheltierescue-com-preview"
@@ -25,4 +25,4 @@ kv_namespaces = [
 
 [env.preview.vars]
 NODE_VERSION = "22"
-NPM_CONFIG_USER_AGENT = "pnpm/9.x.x"
+NPM_CONFIG_USER_AGENT = "npm/10.x.x"


### PR DESCRIPTION
Final Steps:

Delete pnpm-lock.yaml (since npm will now use package-lock.json):

	rm pnpm-lock.yaml

Clear node_modules and reinstall dependencies using npm:

	rm -rf node_modules package-lock.json
	npm install

Confirm npm is set correctly:

	npm --version

Ensure it matches the version you set in volta.

Run a test build:

	npm run build