### PR TITLE
Replace custom `<AdoptableDogs/>` component with Petfinder widget

### DIFF
--- a/src/pages/adoptable-dogs/index.astro
+++ b/src/pages/adoptable-dogs/index.astro
@@ -47,18 +47,19 @@ import { Icon } from 'astro-icon/components';
           <!-- <AdoptableDogs
             client:only="react"
           /> -->
+          <!-- Pet List Widget - Start -->
+          <script src="https://www.petfinder.com/pet-scroller.bundle.js"></script>
           <pet-scroller
-            type='[]'
-            age='[]'
-            limit="48"
+            s3Url="https://dbw3zep4prcju.cloudfront.net/"
+            apiBase="https://psl.petfinder.com/graphql"
+            organization='["d6f7beda-4e29-45df-b0da-93522ec89617"]'
             status="adoptable"
-            petlisttitle=""
-            organization="SC92"
-            apibase="https://api.petfinder.com"
-            petfinderurl="https://www.petfinder.com"
-            accesstoken="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJtd1NmUDQ1SEpPckFSS0RkVGM1M3JGSjNHVTJIdnk0SUxVSGR5Y3NnNGpURzRCVHIzdCIsImp0aSI6IjJUOFRwYVBFM0lmZWpGdFBUTllmbVJOa2ZpcVhQVWFRaDFNbDVZWFkiLCJpYXQiOjE3NjI2MjU5NzYsIm5iZiI6MTc2MjYyNTk3NiwiZXhwIjo0OTE4Mjk5NTc2LCJzdWIiOiIxODAyNzE4OCIsInNjb3BlcyI6W119.QsoPVR0SARewAsI8hrcVeQioiRMDeFkho77XfuyEUKRKoUvWmNoUuyGSwZSwcSRBl-72mkO6PpFk0lTYTLnee1DLpNNFaB0jw2abeGT7MLNidrb-sGX2867FfZ4rt0pwIijvi2ogOj2J50atAnwx7qiC9t82Y4D6bnHzfZj1psSq1LVXiHeRLEkdEbZfhtStX2m724QC7Q45ezXg6NkqwM9SMTJhLBaFQtoTsfOsmqlQJMdtuRkbemLLoxf7sZ_gEl6siwOmF1bjxusf3Wgcn_ESUIta0YtzNt2ecyPq9CB7FThPY3JZ5CbC68bC_GIoOcDzDqU8s63hMhcVIAw_yQ">
+            petfinderUrl="https://www.petfinder.com/"
+            hideBreed="false"
+            limit="48"
+            petListTitle="">
           </pet-scroller>
-          <script src="https://www.petfinder.com/assets/widgets/scripts/main-widgets-web.js" defer></script>
+          <!-- Pet List Widget - End -->
 
           <div class="mb-5"></div>
         </div>


### PR DESCRIPTION
Petfinder API is being decommissioned as of Dec 2, 2025

[help.petfinder.com/s/article/Custom-Pet-List-Widget-Transition-Guide](https://help.petfinder.com/s/article/Custom-Pet-List-Widget-Transition-Guide)

[petfinder.com/tools-widgets/custom-pet-list](https://www.petfinder.com/tools-widgets/custom-pet-list/)

FIX: #637 