### PR TITLE
stop renovate `@types/node` major version bump updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,8 +57,18 @@
       "automerge": false
     },
     {
-      "minimumReleaseAge": "24 hours",
-      "matchPackageNames": ["/^@types\\//"]
+      "matchPackageNames": ["/^@types\\//"],
+      "minimumReleaseAge": "24 hours"
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
NOTE: I will need to manually update `@types/node` after updating the project's `node ` in the future

FIX: https://github.com/scsheltierescue/scsheltierescue.com/issues/634

---

```
    {
      "matchPackageNames": ["/^@types\\//"],
      "minimumReleaseAge": "24 hours"
    },
    {
      "matchPackageNames": ["@types/node"],
      "matchUpdateTypes": ["patch", "minor"],
      "automerge": true
    },
    {
      "matchPackageNames": ["@types/node"],
      "matchUpdateTypes": ["major"],
      "enabled": false
    },
```

Rule 1 (/^@types\//) applies a blanket 24-hour delay for any @types/* package.

Rule 2 then adds behavior specifically for @types/node patch/minor updates — e.g. automerge after the delay.

Rule 3 blocks all major updates for @types/node (no PRs at all), which is the core of your alignment strategy with your current Node LTS/runtime.