### PR TITLE
astro.config.mjs: Experimental preserve scripts order

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,4 +25,7 @@ export default defineConfig({
       'process.env.PETFINDER_API_SECRET': JSON.stringify(process.env.PETFINDER_API_SECRET),
     },
   },
+  experimental: {
+    preserveScriptOrder: true,
+  },
 });


### PR DESCRIPTION
https://docs.astro.build/en/reference/experimental-flags/preserve-scripts-order/

```txt
In a future major version, Astro will preserve
style and script order by default, but you can opt in to the future
behavior early using the experimental.preserveScriptOrder flag.
```

---

FIX: https://github.com/scsheltierescue/scsheltierescue.com/issues/163