### PR TITLE
Temporarily disable broken Petfinder Widget

### DIFF
--- a/src/pages/adoptable-dogs/index.astro
+++ b/src/pages/adoptable-dogs/index.astro
@@ -65,7 +65,7 @@ import { Icon } from 'astro-icon/components';
             <a
               href="https://www.petfinder.com/search/pets-for-adoption/?shelterRescue=d6f7beda-4e29-45df-b0da-93522ec89617"
               target="_blank"
-              class="flex items-center text-xl font-semibold px-6 py-3"
+              class="flex items-center text-xl font-semibold px-6 py-3 text-white rounded-lg bg-primary-c hover:bg-primary-c-darker transition"
             >
               SC Sheltie Rescue Petfinder site
             </a>


### PR DESCRIPTION
Removed the pet-scroller widget temporarily and added a button to link to the SCSR Petfinder site.