### PR TITLE
Add One Lucky Pup community support mention

### DIFF
--- a/src/pages/help/index.astro
+++ b/src/pages/help/index.astro
@@ -25,17 +25,12 @@ import Layout from '@layouts/Layout.astro';
             <li role="menuitem"><a href="/help/articles/fostering">Fostering a Sheltie</a></li>
           </ul>
         </div>
-        {/* TODO before OLP launch:
-            Uncomment this Community Support section after the redesigned One Lucky Pup About page is live at:
-            https://oneluckypup.com/about/
-        */}
-        {/*
+
         <h2 class="headline">Community Support</h2>
         <p>
           South Carolina Sheltie Rescue is grateful for community relationships that support rescue work, foster families, and dogs in transition.
           <a href="https://oneluckypup.com/about/">One Lucky Pup</a> is a Charlotte-area pet care provider offering structured dog daycare, overnight boarding, grooming, and training, and we appreciate their support for local rescue efforts.
         </p>
-        */}
       </main>
     </div>
   </div>

--- a/src/pages/help/index.astro
+++ b/src/pages/help/index.astro
@@ -25,6 +25,9 @@ import Layout from '@layouts/Layout.astro';
             <li role="menuitem"><a href="/help/articles/fostering">Fostering a Sheltie</a></li>
           </ul>
         </div>
+
+        <h2 class="headline">Community Support</h2>
+        <p>South Carolina Sheltie Rescue is grateful for community relationships that support rescue work, foster families, and dogs in transition. <a href="https://www.oneluckypup.com/about/">One Lucky Pup</a> is a Charlotte-area pet care provider offering structured dog daycare, overnight boarding, grooming, training, and support for local rescue efforts.</p>
       </main>
     </div>
   </div>

--- a/src/pages/help/index.astro
+++ b/src/pages/help/index.astro
@@ -25,9 +25,17 @@ import Layout from '@layouts/Layout.astro';
             <li role="menuitem"><a href="/help/articles/fostering">Fostering a Sheltie</a></li>
           </ul>
         </div>
-
+        {/* TODO before OLP launch:
+            Uncomment this Community Support section after the redesigned One Lucky Pup About page is live at:
+            https://oneluckypup.com/about/
+        */}
+        {/*
         <h2 class="headline">Community Support</h2>
-        <p>South Carolina Sheltie Rescue is grateful for community relationships that support rescue work, foster families, and dogs in transition. <a href="https://www.oneluckypup.com/about/">One Lucky Pup</a> is a Charlotte-area pet care provider offering structured dog daycare, overnight boarding, grooming, training, and support for local rescue efforts.</p>
+        <p>
+          South Carolina Sheltie Rescue is grateful for community relationships that support rescue work, foster families, and dogs in transition.
+          <a href="https://oneluckypup.com/about/">One Lucky Pup</a> is a Charlotte-area pet care provider offering structured dog daycare, overnight boarding, grooming, and training, and we appreciate their support for local rescue efforts.
+        </p>
+        */}
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Adds a Community Support section to the Help page mentioning One Lucky Pup as a Charlotte-area pet care provider and community relationship supporting local rescue efforts.

## Notes

This PR should not be merged until the redesigned One Lucky Pup site is live. The target URL, https://oneluckypup.com/about/, currently resolves, but the reciprocal partnership section will not exist there until the OLP redesign is launched.

Once the redesigned OLP About page is live with the South Carolina Sheltie Rescue partnership section, this PR can be merged.

## Link behavior

The One Lucky Pup link is a normal editorial link. It does not use `nofollow` or `sponsored` because this is not a paid placement.